### PR TITLE
Papadopoulos/matrix free duplicate

### DIFF
--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -371,3 +371,17 @@ class ImplicitMatrixContext(object):
         submat.setUp()
 
         return submat
+    
+    def duplicate(self, mat, newmat):
+        newmat_ctx = ImplicitMatrixContext(self.a,
+                                           row_bcs=self.bcs,
+                                           col_bcs=self.bcs_col,
+                                           fc_params=self.fc_params,
+                                           appctx=self.appctx)
+        newmat = PETSc.Mat().create(comm=mat.comm)
+        newmat.setType("python")
+        newmat.setSizes((newmat_ctx.row_sizes, newmat_ctx.col_sizes),
+                        bsize=newmat_ctx.block_size)
+        newmat.setPythonContext(newmat_ctx)
+        newmat.setUp()
+        return newmat

--- a/tests/regression/test_matrix_free.py
+++ b/tests/regression/test_matrix_free.py
@@ -269,3 +269,43 @@ def test_get_info(a, bcs, infotype):
         ctx = A.petscmat.getPythonContext()
         info = ctx.getInfo(A.petscmat, info=itype)
         assert info["memory"] == 2*expect
+
+def test_copy(a, bcs):
+
+    test, trial = a.arguments()
+    
+    if test.function_space().shape == ():
+        rhs_form = inner(Constant(1), test)*dx
+    elif test.function_space().shape == (2, ):
+        rhs_form = inner(Constant((1,1)), test)*dx
+    
+    if bcs is not None:
+        Af = assemble(a, mat_type="matfree", bcs=bcs)
+        rhs= assemble(rhs_form, bcs=bcs)
+    else:
+        Af = assemble(a, mat_type="matfree")
+        rhs = assemble(rhs_form)
+
+    B_petsc = Af.petscmat.copy()
+
+    ksp = PETSc.KSP().create()
+    ksp.setOperators(A.petscmat)
+    ksp.setFromOptions()
+
+    solution1 = Function(test.function_space())
+    solution2 = Function(test.function_space())
+
+    # Solve system with original matrix A
+    with rhs.dat.vec_ro as b:
+        with solution1.dat.vec as x:
+            ksp.solve(b, x)
+
+    # Multiply with copied matrix B
+    with solution1.dat.vec_ro as x:
+        with solution2.dat.vec_ro as y:
+            B_petsc.mult(x, y)
+    # Check if original rhs is equal to BA^-1 (rhs)
+    assert np.allclose(rhs.vector().array(), solution2.vector().array())
+
+
+    


### PR DESCRIPTION
Implementation and test for matrix-free duplicate/copy. Without this implementation, attempting to duplicate or copy an `ImplicitMatrix` would result in the error
```
E   petsc4py.PETSc.Error: error code 83
E   [0] MatDuplicate() line 4575 in firedrake/src/petsc/src/mat/interface/matrix.c
E   [0] MatDuplicate_Python() line 4959 in src/libpetsc4py/libpetsc4py.c
E   [0]
E   [0] method duplicate()
```