### PR TITLE
Fix arguments for duplicate and change test correspondingly

### DIFF
--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -371,11 +371,11 @@ class ImplicitMatrixContext(object):
         submat.setUp()
 
         return submat
-    
+ 
     def duplicate(self, mat, copy):
 
-        if copy == 0:
-            raise NotImplementedError("We do now know how to duplicate a matrix-free MAT with copy = False")
+        if copy is False:
+            raise NotImplementedError("We do now know how to duplicate a matrix-free MAT when copy is False")
         newmat_ctx = ImplicitMatrixContext(self.a,
                                            row_bcs=self.bcs,
                                            col_bcs=self.bcs_col,

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -371,11 +371,11 @@ class ImplicitMatrixContext(object):
         submat.setUp()
 
         return submat
- 
+
     def duplicate(self, mat, copy):
 
-        if copy is False:
-            raise NotImplementedError("We do now know how to duplicate a matrix-free MAT when copy is False")
+        if copy == 0:
+            raise NotImplementedError("We do now know how to duplicate a matrix-free MAT when copy=0")
         newmat_ctx = ImplicitMatrixContext(self.a,
                                            row_bcs=self.bcs,
                                            col_bcs=self.bcs_col,

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -372,7 +372,10 @@ class ImplicitMatrixContext(object):
 
         return submat
     
-    def duplicate(self, mat, newmat):
+    def duplicate(self, mat, copy):
+
+        if copy == 0:
+            raise NotImplementedError("We do now know how to duplicate a matrix-free MAT with copy = False")
         newmat_ctx = ImplicitMatrixContext(self.a,
                                            row_bcs=self.bcs,
                                            col_bcs=self.bcs_col,

--- a/tests/regression/test_matrix_free.py
+++ b/tests/regression/test_matrix_free.py
@@ -270,25 +270,26 @@ def test_get_info(a, bcs, infotype):
         info = ctx.getInfo(A.petscmat, info=itype)
         assert info["memory"] == 2*expect
 
+
 def test_duplicate(a, bcs):
 
     test, trial = a.arguments()
-    
+
     if test.function_space().shape == ():
         rhs_form = inner(Constant(1), test)*dx
     elif test.function_space().shape == (2, ):
-        rhs_form = inner(Constant((1,1)), test)*dx
-    
+        rhs_form = inner(Constant((1, 1)), test)*dx
+
     if bcs is not None:
         Af = assemble(a, mat_type="matfree", bcs=bcs)
-        rhs= assemble(rhs_form, bcs=bcs)
+        rhs = assemble(rhs_form, bcs=bcs)
     else:
         Af = assemble(a, mat_type="matfree")
         rhs = assemble(rhs_form)
 
     # matrix-free duplicate creates a matrix-free copy of Af
     # we have not implemented the default copy = False
-    B_petsc = Af.petscmat.duplicate(copy = True)
+    B_petsc = Af.petscmat.duplicate(copy=True)
 
     ksp = PETSc.KSP().create()
     ksp.setOperators(Af.petscmat)
@@ -299,10 +300,10 @@ def test_duplicate(a, bcs):
 
     # Solve system with original matrix A
     with rhs.dat.vec_ro as b, solution1.dat.vec as x:
-            ksp.solve(b, x)
+        ksp.solve(b, x)
 
     # Multiply with copied matrix B
     with solution1.dat.vec_ro as x, solution2.dat.vec_ro as y:
-            B_petsc.mult(x, y)
+        B_petsc.mult(x, y)
     # Check if original rhs is equal to BA^-1 (rhs)
-    assert np.allclose(rhs.vector().array(), solution2.vector().array()) 
+    assert np.allclose(rhs.vector().array(), solution2.vector().array())

--- a/tests/regression/test_matrix_free.py
+++ b/tests/regression/test_matrix_free.py
@@ -287,7 +287,8 @@ def test_duplicate(a, bcs):
         rhs = assemble(rhs_form)
 
     # matrix-free duplicate creates a matrix-free copy of Af
-    B_petsc = Af.petscmat.duplicate()
+    # we have not implemented the default copy = False
+    B_petsc = Af.petscmat.duplicate(copy = True)
 
     ksp = PETSc.KSP().create()
     ksp.setOperators(Af.petscmat)


### PR DESCRIPTION
Changed the argument in `duplicate` from `newmat` to `copy` (which is a flag equal to 1 if we should copy the values of the original matrix to the new matrix). I was unsure how to create a matrix-free zero matrix, so I just throw a `NotImplementedError` if `copy` is 0.