### PR TITLE
Implementation and test for matfree zeroRowsColumns

### DIFF
--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -105,6 +105,8 @@ def coarsen_form(form, self, coefficient_mapping=None):
 
 @coarsen.register(firedrake.DirichletBC)
 def coarsen_bc(bc, self, coefficient_mapping=None):
+    if type(bc) == firedrake.matrix_free.operators.ZeroRowsColumnsBC:
+        raise NotImplementedError("We do not know how to coarsen ZeroRowsColumnsBC")
     V = self(bc.function_space(), self, coefficient_mapping=coefficient_mapping)
     val = self(bc._original_val, self, coefficient_mapping=coefficient_mapping)
     zeroed = bc._currently_zeroed


### PR DESCRIPTION
This is an implementation for a matfree `zeroRowsColumns` method. Since we are dealing with unassembled matrices, we cannot perform the algebraic operation of zeroing the row and column. So instead when `petsc4py` passes along which row/column, needs to be zeroed, we find its associated dof and make a `ZeroRowsColumnsBC` object (which overloads the `DirichletBC` class) to impose the same effect as zeroing the rows and column of that dof and adding a 1 onto the diagonal. Tests show that this behaves as expected. 